### PR TITLE
FIXED: TypeError "Class constructors cannot be invoked without \'new\'"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015-node"]
 }

--- a/lib/AmazonSESAdapter.js
+++ b/lib/AmazonSESAdapter.js
@@ -1,8 +1,6 @@
 'use strict';
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-var _MailAdapter2 = require('parse-server/lib/Adapters/Email/MailAdapter');
+var _MailAdapter = require('parse-server/lib/Adapters/Email/MailAdapter');
 
 var _amazonSesMailer = require('amazon-ses-mailer');
 
@@ -26,56 +24,42 @@ var _path2 = _interopRequireDefault(_path);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 /**
  * MailAdapter implementation used by the Parse Server to send
  * password reset and email verification emails though AmazonSES
  * @class
  */
-var AmazonSESAdapter = function (_MailAdapter) {
-  _inherits(AmazonSESAdapter, _MailAdapter);
+class AmazonSESAdapter extends _MailAdapter.MailAdapter {
+  constructor(options = {}) {
+    super(options);
 
-  function AmazonSESAdapter() {
-    var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-
-    _classCallCheck(this, AmazonSESAdapter);
-
-    var _this = _possibleConstructorReturn(this, (AmazonSESAdapter.__proto__ || Object.getPrototypeOf(AmazonSESAdapter)).call(this, options));
-
-    var accessKeyId = options.accessKeyId;
-    var secretAccessKey = options.secretAccessKey;
-    var region = options.region;
-    var fromAddress = options.fromAddress;
-
+    const {
+      accessKeyId,
+      secretAccessKey,
+      region,
+      fromAddress
+    } = options;
     if (!accessKeyId || !secretAccessKey || !region || !fromAddress) {
       throw new Error('AmazonSESAdapter requires valid fromAddress, accessKeyId, secretAccessKey, region.');
     }
 
-    var _options$templates = options.templates;
-    var templates = _options$templates === undefined ? {} : _options$templates;
-
-    ['passwordResetEmail', 'verificationEmail'].forEach(function (key) {
-      var _ref = templates[key] || {};
-
-      var subject = _ref.subject;
-      var pathPlainText = _ref.pathPlainText;
-      var callback = _ref.callback;
-
+    const {
+      templates = {}
+    } = options;
+    ['passwordResetEmail', 'verificationEmail'].forEach(key => {
+      const {
+        subject,
+        pathPlainText,
+        callback
+      } = templates[key] || {};
       if (typeof subject !== 'string' || typeof pathPlainText !== 'string') throw new Error('AmazonSESAdapter templates are not properly configured.');
 
       if (callback && typeof callback !== 'function') throw new Error('AmazonSESAdapter template callback is not a function.');
     });
 
-    _this.ses = new _amazonSesMailer2.default(accessKeyId, secretAccessKey, region);
-    _this.fromAddress = fromAddress;
-    _this.templates = templates;
-
-    return _this;
+    this.ses = new _amazonSesMailer2.default(accessKeyId, secretAccessKey, region);
+    this.fromAddress = fromAddress;
+    this.templates = templates;
   }
 
   /**
@@ -89,248 +73,189 @@ var AmazonSESAdapter = function (_MailAdapter) {
    * @param {string} options.pathHtml, path to html version of email template
    * @returns {promise}
    */
+  _sendMail(options) {
+    const loadEmailTemplate = this.loadEmailTemplate;
+    let message = {},
+        templateVars = {},
+        pathPlainText,
+        pathHtml;
 
+    if (options.templateName) {
+      const {
+        templateName,
+        subject,
+        fromAddress,
+        recipient,
+        variables
+      } = options;
+      let template = this.templates[templateName];
 
-  _createClass(AmazonSESAdapter, [{
-    key: '_sendMail',
-    value: function _sendMail(options) {
-      var _this2 = this;
+      if (!template) throw new Error(`Could not find template with name ${templateName}`);
+      if (!subject && !template.subject) throw new Error(`Cannot send email with template ${templateName} without a subject`);
+      if (!recipient) throw new Error(`Cannot send email with template ${templateName} without a recipient`);
 
-      var loadEmailTemplate = this.loadEmailTemplate;
-      var message = {},
-          templateVars = {},
-          pathPlainText = void 0,
-          pathHtml = void 0;
+      pathPlainText = template.pathPlainText;
+      pathHtml = template.pathHtml;
 
-      if (options.templateName) {
-        var templateName = options.templateName;
-        var subject = options.subject;
-        var fromAddress = options.fromAddress;
-        var recipient = options.recipient;
-        var variables = options.variables;
+      templateVars = variables;
 
-        var _template = this.templates[templateName];
+      message = {
+        from: fromAddress || this.fromAddress,
+        to: recipient,
+        subject: subject || template.subject
+      };
+    } else {
+      const {
+        link,
+        appName,
+        user,
+        templateConfig
+      } = options;
+      const {
+        callback
+      } = templateConfig;
+      let userVars;
 
-        if (!_template) throw new Error('Could not find template with name ' + templateName);
-        if (!subject && !_template.subject) throw new Error('Cannot send email with template ' + templateName + ' without a subject');
-        if (!recipient) throw new Error('Cannot send email with template ' + templateName + ' without a recipient');
-
-        pathPlainText = _template.pathPlainText;
-        pathHtml = _template.pathHtml;
-
-        templateVars = variables;
-
-        message = {
-          from: fromAddress || this.fromAddress,
-          to: recipient,
-          subject: subject || _template.subject
-        };
-      } else {
-        var link = options.link;
-        var appName = options.appName;
-        var user = options.user;
-        var templateConfig = options.templateConfig;
-        var callback = templateConfig.callback;
-
-        var userVars = void 0;
-
-        if (callback && typeof callback === 'function') {
-          userVars = callback(user);
-          // If custom user variables are not packaged in an object, ignore it
-          var validUserVars = userVars && userVars.constructor && userVars.constructor.name === 'Object';
-          userVars = validUserVars ? userVars : {};
-        }
-
-        pathPlainText = templateConfig.pathPlainText;
-        pathHtml = templateConfig.pathHtml;
-
-        templateVars = Object.assign({
-          link: link,
-          appName: appName,
-          username: user.get('username'),
-          email: user.get('email')
-        }, userVars);
-
-        message = {
-          from: this.fromAddress,
-          to: user.get('email'),
-          subject: templateConfig.subject
-        };
+      if (callback && typeof callback === 'function') {
+        userVars = callback(user);
+        // If custom user variables are not packaged in an object, ignore it
+        const validUserVars = userVars && userVars.constructor && userVars.constructor.name === 'Object';
+        userVars = validUserVars ? userVars : {};
       }
 
-      return (0, _co2.default)(regeneratorRuntime.mark(function _callee() {
-        var plainTextEmail, htmlEmail, compiled;
-        return regeneratorRuntime.wrap(function _callee$(_context) {
-          while (1) {
-            switch (_context.prev = _context.next) {
-              case 0:
-                plainTextEmail = void 0, htmlEmail = void 0, compiled = void 0;
+      pathPlainText = templateConfig.pathPlainText;
+      pathHtml = templateConfig.pathHtml;
 
-                // Load plain-text version
+      templateVars = Object.assign({
+        link,
+        appName,
+        username: user.get('username'),
+        email: user.get('email')
+      }, userVars);
 
-                _context.next = 3;
-                return loadEmailTemplate(pathPlainText);
+      message = {
+        from: this.fromAddress,
+        to: user.get('email'),
+        subject: templateConfig.subject
+      };
+    }
 
-              case 3:
-                plainTextEmail = _context.sent;
+    return (0, _co2.default)(function* () {
+      let plainTextEmail, htmlEmail, compiled;
 
-                plainTextEmail = plainTextEmail.toString('utf8');
+      // Load plain-text version
+      plainTextEmail = yield loadEmailTemplate(pathPlainText);
+      plainTextEmail = plainTextEmail.toString('utf8');
 
-                // Compile plain-text template
-                compiled = (0, _lodash2.default)(plainTextEmail, {
-                  interpolate: /{{([\s\S]+?)}}/g
-                });
-                // Add processed text to the message object
-                message.text = compiled(templateVars);
+      // Compile plain-text template
+      compiled = (0, _lodash2.default)(plainTextEmail, {
+        interpolate: /{{([\s\S]+?)}}/g
+      });
+      // Add processed text to the message object
+      message.text = compiled(templateVars);
 
-                // Load html version if available
-
-                if (!pathHtml) {
-                  _context.next = 13;
-                  break;
-                }
-
-                _context.next = 10;
-                return loadEmailTemplate(pathHtml);
-
-              case 10:
-                htmlEmail = _context.sent;
-
-                // Compile html template
-                compiled = (0, _lodash2.default)(htmlEmail, {
-                  interpolate: /{{([\s\S]+?)}}/g
-                });
-                // Add processed HTML to the message object
-                message.html = compiled(templateVars);
-
-              case 13:
-                return _context.abrupt('return', {
-                  from: message.from,
-                  to: [message.to],
-                  subject: message.subject,
-                  body: {
-                    text: message.text,
-                    html: message.html
-                  }
-                });
-
-              case 14:
-              case 'end':
-                return _context.stop();
-            }
-          }
-        }, _callee, this);
-      })).then(function (payload) {
-        return new Promise(function (resolve, reject) {
-          _this2.ses.send(payload, function (error, data) {
-            if (error) reject(error);
-            resolve(data);
-          });
+      // Load html version if available
+      if (pathHtml) {
+        htmlEmail = yield loadEmailTemplate(pathHtml);
+        // Compile html template
+        compiled = (0, _lodash2.default)(htmlEmail, {
+          interpolate: /{{([\s\S]+?)}}/g
         });
-      }, function (error) {
-        console.error(error);
-      });
-    }
+        // Add processed HTML to the message object
+        message.html = compiled(templateVars);
+      }
 
-    /**
-     * _sendMail wrapper to send an email with password reset link
-     * @param {object} options, options object with the following parameters:
-     * @param {string} options.link, to reset password or verify email address
-     * @param {string} options.appName, the name of the parse-server app
-     * @param {object} options.user, the Parse.User object
-     * @returns {promise}
-     */
-
-  }, {
-    key: 'sendPasswordResetEmail',
-    value: function sendPasswordResetEmail(_ref2) {
-      var link = _ref2.link;
-      var appName = _ref2.appName;
-      var user = _ref2.user;
-
-      return this._sendMail({
-        link: link,
-        appName: appName,
-        user: user,
-        templateConfig: this.templates.passwordResetEmail
-      });
-    }
-
-    /**
-     * _sendMail wrapper to send an email with an account verification link
-     * @param {object} options, options object with the following parameters:
-     * @param {string} options.link, to reset password or verify email address
-     * @param {string} options.appName, the name of the parse-server app
-     * @param {object} options.user, the Parse.User object
-     * @returns {promise}
-     */
-
-  }, {
-    key: 'sendVerificationEmail',
-    value: function sendVerificationEmail(_ref3) {
-      var link = _ref3.link;
-      var appName = _ref3.appName;
-      var user = _ref3.user;
-
-      return this._sendMail({
-        link: link,
-        appName: appName,
-        user: user,
-        templateConfig: this.templates.verificationEmail
-      });
-    }
-
-    /**
-     * _sendMail wrapper to send general purpose emails
-     * @param {object} options, options object with the following parameters:
-     * @param {object} options.templateName, name of template to be used
-     * @param {object} options.subject, overrides the default value
-     * @param {object} options.fromAddress, overrides the default from address
-     * @param {object} options.recipient, email's recipient
-     * @param {object} options.variables, an object whose property names represent
-     *   template variables,vand whose values will replace the template variable
-     *   placeholders
-     * @returns {promise}
-     */
-
-  }, {
-    key: 'send',
-    value: function send(_ref4) {
-      var templateName = _ref4.templateName;
-      var subject = _ref4.subject;
-      var fromAddress = _ref4.fromAddress;
-      var recipient = _ref4.recipient;
-      var _ref4$variables = _ref4.variables;
-      var variables = _ref4$variables === undefined ? {} : _ref4$variables;
-
-      return this._sendMail({
-        templateName: templateName,
-        subject: subject,
-        fromAddress: fromAddress,
-        recipient: recipient,
-        variables: variables
-      });
-    }
-
-    /**
-     * Simple Promise wrapper to asynchronously fetch the contents of a template.
-     * @param {string} path
-     * @returns {promise}
-     */
-
-  }, {
-    key: 'loadEmailTemplate',
-    value: function loadEmailTemplate(path) {
-      return new Promise(function (resolve, reject) {
-        _fs2.default.readFile(path, function (err, data) {
-          if (err) reject(err);
+      return {
+        from: message.from,
+        to: [message.to],
+        subject: message.subject,
+        body: {
+          text: message.text,
+          html: message.html
+        }
+      };
+    }).then(payload => {
+      return new Promise((resolve, reject) => {
+        this.ses.send(payload, (error, data) => {
+          if (error) reject(error);
           resolve(data);
         });
       });
-    }
-  }]);
+    }, error => {
+      console.error(error);
+    });
+  }
 
-  return AmazonSESAdapter;
-}(_MailAdapter2.MailAdapter);
+  /**
+   * _sendMail wrapper to send an email with password reset link
+   * @param {object} options, options object with the following parameters:
+   * @param {string} options.link, to reset password or verify email address
+   * @param {string} options.appName, the name of the parse-server app
+   * @param {object} options.user, the Parse.User object
+   * @returns {promise}
+   */
+  sendPasswordResetEmail({ link, appName, user }) {
+    return this._sendMail({
+      link,
+      appName,
+      user,
+      templateConfig: this.templates.passwordResetEmail
+    });
+  }
+
+  /**
+   * _sendMail wrapper to send an email with an account verification link
+   * @param {object} options, options object with the following parameters:
+   * @param {string} options.link, to reset password or verify email address
+   * @param {string} options.appName, the name of the parse-server app
+   * @param {object} options.user, the Parse.User object
+   * @returns {promise}
+   */
+  sendVerificationEmail({ link, appName, user }) {
+    return this._sendMail({
+      link,
+      appName,
+      user,
+      templateConfig: this.templates.verificationEmail
+    });
+  }
+
+  /**
+   * _sendMail wrapper to send general purpose emails
+   * @param {object} options, options object with the following parameters:
+   * @param {object} options.templateName, name of template to be used
+   * @param {object} options.subject, overrides the default value
+   * @param {object} options.fromAddress, overrides the default from address
+   * @param {object} options.recipient, email's recipient
+   * @param {object} options.variables, an object whose property names represent
+   *   template variables,vand whose values will replace the template variable
+   *   placeholders
+   * @returns {promise}
+   */
+  send({ templateName, subject, fromAddress, recipient, variables = {} }) {
+    return this._sendMail({
+      templateName,
+      subject,
+      fromAddress,
+      recipient,
+      variables
+    });
+  }
+
+  /**
+   * Simple Promise wrapper to asynchronously fetch the contents of a template.
+   * @param {string} path
+   * @returns {promise}
+   */
+  loadEmailTemplate(path) {
+    return new Promise((resolve, reject) => {
+      _fs2.default.readFile(path, (err, data) => {
+        if (err) reject(err);
+        resolve(data);
+      });
+    });
+  }
+
+}
 
 module.exports = AmazonSESAdapter;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
     "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015-node": "^6.1.1",
     "chai": "^3.5.0",
     "mocha": "^2.5.3",
     "sinon": "^1.17.4"


### PR DESCRIPTION
This PR fixes the bug I described in [my issue](https://github.com/ecohealthalliance/parse-server-amazon-ses-email-adapter/issues/3).

I made the fix in my fork: https://github.com/charleskoehl/parse-server-amazon-ses-email-adapter/network